### PR TITLE
chore: Add restart option to always restart containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   openldap:
     env_file: .env
     image: osixia/openldap:latest
+    restart: always
     container_name: ${LDAP_ORGANISATION}_openldap
     hostname: openldap
     ports:
@@ -42,6 +43,7 @@ services:
 
   phpldapadmin:
     image: osixia/phpldapadmin:latest
+    restart: always
     container_name: ${LDAP_ORGANISATION}_phpldapadmin
     hostname: phpldapadmin
     ports:


### PR DESCRIPTION
## Description

`restart: always` 옵션을 추가하여 컨테이너가 Docker 실행 시 자동으로 재시동되게 업데이트함.

## References

[Start containers automatically - Docker docs](https://docs.docker.com/config/containers/start-containers-automatically/)